### PR TITLE
Fixed messages not having an id and BTTV error 

### DIFF
--- a/ChatCore/Services/Twitch/BTTVDataProvider.cs
+++ b/ChatCore/Services/Twitch/BTTVDataProvider.cs
@@ -1,4 +1,4 @@
-﻿using ChatCore.Interfaces;
+using ChatCore.Interfaces;
 using ChatCore.Models;
 using Microsoft.Extensions.Logging;
 using System;
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Net.Http;
 using System.Threading.Tasks;
 using ChatCore.Utilities;
+using System.Reflection;
 
 namespace ChatCore.Services.Twitch
 {
@@ -30,6 +31,7 @@ namespace ChatCore.Services.Twitch
 			{
 				_logger.LogDebug($"Requesting BTTV {(isGlobal ? "global " : "")}emotes{(isGlobal ? "." : $" for channel {category}")}.");
 				using var msg = new HttpRequestMessage(HttpMethod.Get, isGlobal ? "https://api.betterttv.net/2/emotes" : $"https://api.betterttv.net/2/channels/{category}");
+				msg.Headers.Add("User-Agent", $"ChatCore/{Assembly.GetExecutingAssembly().GetName().Version}");
 				var resp = await _httpClient.SendAsync(msg);
 				if (!resp.IsSuccessStatusCode)
 				{

--- a/ChatCore/Services/Twitch/TwitchService.cs
+++ b/ChatCore/Services/Twitch/TwitchService.cs
@@ -317,7 +317,7 @@ namespace ChatCore.Services.Twitch
 
         internal void SendTextMessage(Assembly assembly, string message, string channel)
         {
-            _textMessageQueue.Enqueue(new KeyValuePair<Assembly, string>(assembly, $"@id={System.Guid.NewGuid().ToString()} PRIVMSG #{channel} :{message}"));
+            _textMessageQueue.Enqueue(new KeyValuePair<Assembly, string>(assembly, $"@id={Guid.NewGuid().ToString()} PRIVMSG #{channel} :{message}"));
         }
 
         public void SendTextMessage(string message, string channel)

--- a/ChatCore/Services/Twitch/TwitchService.cs
+++ b/ChatCore/Services/Twitch/TwitchService.cs
@@ -1,4 +1,4 @@
-﻿using ChatCore.Interfaces;
+using ChatCore.Interfaces;
 using ChatCore.Models;
 using ChatCore.Models.Twitch;
 using Microsoft.Extensions.Logging;
@@ -317,7 +317,7 @@ namespace ChatCore.Services.Twitch
 
         internal void SendTextMessage(Assembly assembly, string message, string channel)
         {
-            _textMessageQueue.Enqueue(new KeyValuePair<Assembly, string>(assembly, $"PRIVMSG #{channel} :{message}"));
+            _textMessageQueue.Enqueue(new KeyValuePair<Assembly, string>(assembly, $"@id={System.Guid.NewGuid().ToString()} PRIVMSG #{channel} :{message}"));
         }
 
         public void SendTextMessage(string message, string channel)

--- a/ChatCore/Services/Twitch/TwitchService.cs
+++ b/ChatCore/Services/Twitch/TwitchService.cs
@@ -1,15 +1,15 @@
-using ChatCore.Interfaces;
-using ChatCore.Models;
-using ChatCore.Models.Twitch;
-using Microsoft.Extensions.Logging;
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using ChatCore.Interfaces;
+using ChatCore.Models;
+using ChatCore.Models.Twitch;
 using ChatCore.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace ChatCore.Services.Twitch
 {


### PR DESCRIPTION
- Messages sent by SendTextMessages() didn't have an id
- BTTV "Forbidden" error when requesting emotes, adding an user-agent fixes it